### PR TITLE
Fixed KeyError in get_note_list() when offline

### DIFF
--- a/simplenote/simplenote.py
+++ b/simplenote/simplenote.py
@@ -269,8 +269,8 @@ class Simplenote(object):
                 note_object = self.__add_simplenote_api_fields(n['d'], n['id'], n['v'])
                 note_objects.append(note_object)
             notes["index"].extend(note_objects)
-        except IOError:
-            status = -1
+        except IOError as e:
+            return e, -1
 
         # get additional notes if bookmark was set in response
         while "mark" in response_notes:
@@ -291,8 +291,8 @@ class Simplenote(object):
                     note_object = self.__add_simplenote_api_fields(n['d'], n['id'], n['v'])
                     note_objects.append(note_object)
                 notes["index"].extend(note_objects)
-            except IOError:
-                status = -1
+            except IOError as e:
+                return e, -1
         note_list = notes["index"]
         self.current = response_notes["current"]
         # Can only filter for tags at end, once all notes have been retrieved.


### PR DESCRIPTION
Reproduction code
------------------

    import simplenote
    sn = simplenote.Simplenote(username='dummy', password='dummy')

    # OK
    assert sn.get_note('dummy')[1] < 0
    assert sn.add_note('dummy')[1] < 0
    assert sn.trash_note('dummy')[1] < 0
    assert sn.delete_note('dummy')[1] < 0

    # It will raise the KeyError when offline.
    # Tested with simplenote v2.1.0.
    assert sn.get_note_list()[1] < 0