### PR TITLE
Fix typerror when offline

### DIFF
--- a/simplenote/simplenote.py
+++ b/simplenote/simplenote.py
@@ -11,21 +11,15 @@
 import sys
 if sys.version_info > (3, 0):
     import urllib.request as urllib2
-    import urllib.error
     from urllib.error import HTTPError
-    import urllib.parse as urllib
-    import html
     from http.client import HTTPException, BadStatusLine
 else:
     import urllib2
     from urllib2 import HTTPError
-    import urllib
-    from HTMLParser import HTMLParser
     from httplib import HTTPException, BadStatusLine
 
 import base64
 import time
-import datetime
 import uuid
 
 try:

--- a/tests/test_simplenote.py
+++ b/tests/test_simplenote.py
@@ -45,9 +45,17 @@ class TestSimplenote(unittest.TestCase):
         token = self.simplenote_instance.get_token()
         self.assertNotEqual(None, token)
 
-    def test_simplenote_failed_auth(self):
-        s = simplenote.Simplenote(self.user, "")
+    def test_simplenote_failed_auth_with_incorrect_password(self):
+        s = simplenote.Simplenote(self.user, "incorrect-password")
         self.assertRaises(simplenote.SimplenoteLoginFailed, s.get_token)
+
+    def test_simplenote_failed_auth_with_empty_password(self):
+        s = simplenote.Simplenote(self.user, "")
+        self.assertRaises(Exception, s.get_token)
+
+    def test_simplenote_failed_auth_with_empty_email_address(self):
+        s = simplenote.Simplenote("", "foo")
+        self.assertRaises(Exception, s.get_token)
 
     def test_simplenote_get_list_length(self):
         res, status = self.simplenote_instance.get_note_list()


### PR DESCRIPTION
Simplenote.authenticate() and get_token() usually return a str.  When offline, these methods return None.  Some methods do not consider for this behavior.  Therefore, None will be set to http header, and TypeError will occur when sending a request.

Related issue: cpbotha/nvpy#191

BROKEN CHANGE:
authenticate() and get_token() no longer catch the IOError, BadStatusLine and part of HTTPError errors.